### PR TITLE
Potential fix for code scanning alert no. 24: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,6 +11,8 @@ on:
     - cron: "0 0 * * 0" # Weekly rebuild (Sunday at midnight)
   workflow_dispatch:
     
+permissions:
+  contents: read
 
 jobs:
 


### PR DESCRIPTION
Potential fix for [https://github.com/rzkw/walkable/security/code-scanning/24](https://github.com/rzkw/walkable/security/code-scanning/24)

In general, the problem is fixed by explicitly specifying a restrictive `permissions` block so the `GITHUB_TOKEN` does not inherit broad repository defaults. We should grant only what is needed: the `build` job only needs to read the repository contents and possibly packages, so `contents: read` (and optionally `packages: read`) is enough. The `upgrade-packages` job already has its own `permissions` block with `contents: write` and `pull-requests: write`, which we should leave unchanged.

The best minimal fix without changing functionality is to add a workflow-level `permissions` block that applies to all jobs by default, placed after the `on:` section and before `jobs:`. This block should set `contents: read` (and optionally `packages: read`, but the CodeQL suggestion only requires `contents: read`). Because `upgrade-packages` already defines its own permissions, it will continue to have write access; the `build` job will now inherit the new read-only permissions, satisfying the least-privilege requirement and addressing the CodeQL warning on line 18.

Concretely:
- Edit `.github/workflows/node.js.yml`.
- Insert:
  ```yaml
  permissions:
    contents: read
  ```
  between the `on:` block (ending at line 12–13) and the `jobs:` key at line 15.
- No other changes, imports, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
