### PR TITLE
fix: resolve workflow issues in ts-buildx.yml

### DIFF
--- a/.github/workflows/ts-buildx.yml
+++ b/.github/workflows/ts-buildx.yml
@@ -24,22 +24,22 @@ jobs:
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:ci
           version: latest
-          ping: "acer.tailea2d68.ts.net,home.tailea2d68.ts.net"
+          ping: ${{ secrets.AMD_HOST }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.GHA_RUNNER }}
 
       - name: Docker Setup Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
         with:
           buildkitd-flags: --debug
           driver: docker-container
-          endpoint: ssh://rizky@acer.tailea2d68.ts.net:22
+          endpoint: tcp://${{ secrets.AMD_HOST }}:9999
           append: |
-            - endpoint:ssh://rizky@home.tailea2d68.ts.net:22
+            - endpoint: tcp://${{ secrets.ARM_HOST }}:9999
               platforms: linux/arm64
 
       - name: Build and push

--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,4 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-.dev.vars
+.dev.vars.worktrees

--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,5 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-.dev.vars.worktrees
+.dev.vars
+.worktrees


### PR DESCRIPTION
## Changes

- Fixed ARM endpoint port (was missing `:9999`)
- Fixed secret name (`GHA-RUNNER` → `GHA_RUNNER` — hyphens not allowed in GitHub Actions secrets)
- Removed `.vscode/settings.json` (contained local file path)
- Added `.vscode/` to `.gitignore`

## Related

Closes #135 (supersedes stale workflow branch)