### PR TITLE
feat: add Tech Stack section to home page

### DIFF
--- a/app/data.ts
+++ b/app/data.ts
@@ -23,6 +23,11 @@ type BlogPost = {
   uid: string
 }
 
+type TechStack = {
+  category: string
+  skills: string
+}
+
 type SocialLink = {
   label: string
   link: string
@@ -151,6 +156,24 @@ export const SOCIAL_LINKS: SocialLink[] = [
   {
     label: 'Seek',
     link: 'http://seek.com.au/profile/rizky-ramadhani-l8CSc2jM2s',
+  },
+]
+
+export const TECH_STACK: TechStack[] = [
+  {
+    category: 'Proficient in:',
+    skills:
+      'Git • Docker • Linux • Bash • Ubuntu • GitHub • RHEL • Networking (TCP/IP, DNS) • VS Code • macOS',
+  },
+  {
+    category: 'Experienced with:',
+    skills:
+      'GitHub Actions • Jira • Cloudflare • Grafana • MCP (Model Context Protocol) • Opencode • Slack • Claude',
+  },
+  {
+    category: 'Exposure to:',
+    skills:
+      'Oracle Cloud Infrastructure • Terraform • YAML • AWS • Ansible • Azure • PowerShell • Python • JavaScript • Vercel • Kubernetes',
   },
 ]
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,6 +18,7 @@ import {
   BLOG_POSTS,
   EMAIL,
   SOCIAL_LINKS,
+  TECH_STACK,
 } from './data'
 
 const VARIANTS_CONTAINER = {
@@ -139,6 +140,25 @@ export default function Personal() {
           <p className="text-zinc-600 dark:text-zinc-400">
             Documentation of infra projects and Linux systems admin.
           </p>
+        </div>
+      </motion.section>
+
+      <motion.section
+        variants={VARIANTS_SECTION}
+        transition={TRANSITION_SECTION}
+      >
+        <h3 className="mb-5 text-lg font-medium">Tech Stack</h3>
+        <div className="flex flex-col space-y-2">
+          {TECH_STACK.map((item) => (
+            <div key={item.category}>
+              <span className="font-normal dark:text-zinc-100">
+                {item.category}
+              </span>{' '}
+              <span className="text-zinc-500 dark:text-zinc-400">
+                {item.skills}
+              </span>
+            </div>
+          ))}
         </div>
       </motion.section>
 


### PR DESCRIPTION
From plan `plans/2026-08-03-pr159-review-fixes.md` (Tasks 2-3).

- Adds `TECH_STACK` constant to `app/data.ts` (Proficient in / Experienced with / Exposure to)
- Renders Tech Stack section above Selected Projects on `app/page.tsx`
- Category labels use blog-title style (white), tech uses blog-subtitle grey
- Verified: `next build` passes (TS + 15 static routes)

Note: `npm run lint` is broken repo-wide (Next 16 removed `next lint`; eslint 9 flat-config circular error) — pre-existing, not from this change.