### PR TITLE
feat: Link response header on homepage

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,18 +1,31 @@
-import createMDX from '@next/mdx';
-import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare";
+import createMDX from '@next/mdx'
+import { initOpenNextCloudflareForDev } from '@opennextjs/cloudflare'
 
 // This line patches the Next.js dev server for Cloudflare bindings
-initOpenNextCloudflareForDev();
+initOpenNextCloudflareForDev()
 
-// @type {import('next').NextConfig} 
+// @type {import('next').NextConfig}
 const nextConfig = {
   reactStrictMode: true,
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx'],
   output: 'standalone',
-};
+  async headers() {
+    return [
+      {
+        source: '/',
+        headers: [
+          {
+            key: 'Link',
+            value: '</llms.txt>; rel="describedby"',
+          },
+        ],
+      },
+    ]
+  },
+}
 
 const withMDX = createMDX({
   extension: /\.mdx?$/,
-});
+})
 
-export default withMDX(nextConfig);
+export default withMDX(nextConfig)


### PR DESCRIPTION
## Plan — Change 1: `next.config.mjs` — Link header on homepage

> Add `headers()` function:
>
> ```js
> async headers() {
>   return [
>     {
>       source: '/',
>       headers: [
>         {
>           key: 'Link',
>           value: '</llms.txt>; rel="describedby"',
>         },
>       ],
>     },
>   ];
> },
> ```
>
> Returns `Link: </llms.txt>; rel="describedby"` on `GET /` per RFC 8288 §3.

## What's Skipped

- **API catalog** (`/.well-known/api-catalog`) — no APIs to advertise. Add when endpoints exist.
- **Middleware** — `next.config.mjs` headers is simpler, no runtime cost.

## Validation

Tested locally with `npm run build` + `npx next start -p 3100`:

```bash
$ curl -sI http://localhost:3100/ | grep -i link
Link: </llms.txt>; rel="describedby"

$ curl -sI http://localhost:3100/llms.txt | head -3
HTTP/1.1 200 OK
Accept-Ranges: bytes
Cache-Control: public, max-age=0
```

Both pass. After merge, verify on production:

```bash
curl -I https://www.walk-llc.com/ | grep -i link
# Expected: Link: </llms.txt>; rel="describedby"
```

Or [isitagentready.com](https://isitagentready.com/api/scan): `{"url": "https://www.walk-llc.com"}`

## References

- [RFC 8288](https://www.rfc-editor.org/rfc/rfc8288) — Web Linking, Link header field (§3)
- [isitagentready.com skill](https://isitagentready.com/.well-known/agent-skills/link-headers/SKILL.md)

See `plans/2026-08-05-link-headers-llms-txt.md` for full plan.
Parent plan PR: #168