### PR TITLE
docs: require testing before every PR submission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,12 @@ Next.js website for Walkable LLC. Deployed to Cloudflare Workers and Docker.
 
 All commits must be signed with SSH key `~/.ssh/agent-gh-signing`. Git is configured globally (`gpg.format = ssh`, `user.signingkey = ~/.ssh/agent-gh-signing.pub`, `commit.gpgsign = true`). Verify with `git log --show-signature -1` before pushing.
 
+## Testing before PR
+
+- **Always test before submitting a PR, regardless of content** (code, plans, references, etc).
+- Run the exact commands and include the commands + their output in the PR description.
+- For non-code changes (docs, plans), verify whatever is verifiable (e.g. `git diff --stat`, build succeeds, config parses).
+
 # Walkable LLC — Project Instructions
 
 ## Planning


### PR DESCRIPTION
Adds a `## Testing before PR` section to `AGENTS.md` requiring tests before every PR submission, regardless of content.

## Changes

`AGENTS.md` — new section:

- Always test before submitting a PR, regardless of content (code, plans, references, etc).
- Run the exact commands and include the commands + their output in the PR description.
- For non-code changes (docs, plans), verify whatever is verifiable (e.g. `git diff --stat`, build succeeds, config parses).

## Validation

Docs change — verified the file diff:

```bash
$ git diff AGENTS.md
@@ -12,6 +12,12 @@
 All commits must be signed with SSH key `~/.ssh/agent-gh-signing`...

+## Testing before PR
+
+- **Always test before submitting a PR, regardless of content** (code, plans, references, etc).
+- Run the exact commands and include the commands + their output in the PR description.
+- For non-code changes (docs, plans), verify whatever is verifiable (e.g. `git diff --stat`, build succeeds, config parses).
+
 # Walkable LLC — Project Instructions

$ git diff --stat
 AGENTS.md | 6 ++++++
 1 file changed, 6 insertions(+)
```